### PR TITLE
feat: add dark mode image filter to images

### DIFF
--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -34,6 +34,10 @@ html.dark {
   --primary: 70.35% 0.145 271.74;
 }
 
+html.dark img {
+  filter: brightness(.75) contrast(1.1);
+}
+
 *::selection {
   color: oklch(var(--primary));
   background-color: oklch(var(--primary) / 0.15);


### PR DESCRIPTION
## Overview

This pull request adds `filter` style on `img` elements in dark mode that dims the image brightness to prevent bright images to be jarring on dark mode. Inspired by [Dark Mode - CSS Tricks](https://css-tricks.com/a-complete-guide-to-dark-mode-on-the-web/) post.