### PR TITLE
fix: re-add missing font definition

### DIFF
--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -35,7 +35,7 @@ html.dark {
 }
 
 html.dark img {
-  filter: brightness(.75) contrast(1.1);
+  filter: brightness(.8) contrast(1.1);
 }
 
 *::selection {
@@ -61,7 +61,6 @@ html.dark img {
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-
 }
 
 @font-face {
@@ -72,7 +71,15 @@ html.dark img {
   font-style: normal;
   font-weight: 500;
   font-display: swap;
+}
 
+@font-face {
+  font-family: "JetBrains Mono";
+  src: local("JetBrains Mono"),
+    url("/fonts/jetbrains-mono.woff2") format("woff2");
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
 }
 
 ::-webkit-scrollbar {

--- a/src/components/vue/CommandMenu.vue
+++ b/src/components/vue/CommandMenu.vue
@@ -160,9 +160,14 @@ watch(searchTerm, () => {
           transition-all
           shadow
           md:top-8
-          lg:shadow-none"
+          lg:shadow-none
+          grid
+          place-items-center"
       >
-        <span class="mt-1">⌘</span>
+        <Icon
+          icon="lucide:command"
+          class="w-4 h-4"
+        />
         <p
           class="absolute -bottom-8 text-sm  transition-all opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 group-focus:opacity-100 group-focus:translate-y-0"
         >


### PR DESCRIPTION
## Overview

This pull request re-adds CSS definition for missing `JetBrains Mono` font in the global CSS file. 