### PR TITLE
fix: pass base64 image to satori

### DIFF
--- a/src/pages/posts/og-[...slug].png.ts
+++ b/src/pages/posts/og-[...slug].png.ts
@@ -9,8 +9,6 @@ import satori, { type SatoriOptions } from 'satori';
 import { Template } from './og-template';
 
 interface Params {
-  host: string;
-
   title: string;
   publishedAt: Date;
   timeToRead: number;
@@ -37,7 +35,9 @@ async function generateOGImage(params: Params) {
     ],
   };
 
-  const svg = await satori(Template(params), opts);
+  const logoBuffer = readFileSync('./public/og-logo.png');
+
+  const svg = await satori(Template(params, logoBuffer), opts);
 
   const sharpSvg = Buffer.from(svg);
 
@@ -47,11 +47,7 @@ async function generateOGImage(params: Params) {
 }
 
 export async function GET(ctx: APIContext) {
-  const host = import.meta.env.DEV ? `${ctx.url.protocol}//${ctx.url.host}` : import.meta.env.SITE;
-  const image = await generateOGImage({
-    ...ctx.props as Params,
-    host,
-  });
+  const image = await generateOGImage(ctx.props as Params);
 
   return new Response(image, {
     status: 200,

--- a/src/pages/posts/og-[...slug].png.ts
+++ b/src/pages/posts/og-[...slug].png.ts
@@ -1,10 +1,11 @@
 import { readFileSync } from 'node:fs';
-import sharp from 'sharp';
 
 import { getCollection } from 'astro:content';
 import type { APIContext } from 'astro';
 
 import satori, { type SatoriOptions } from 'satori';
+import sharp from 'sharp';
+import getReadingTime from 'reading-time';
 
 import { Template } from './og-template';
 
@@ -67,7 +68,7 @@ export async function getStaticPaths() {
     props: {
       title: post.data.title,
       publishedAt: post.data.publishedAt,
-      timeToRead: (post.data as { timeToRead: number; }).timeToRead,
+      timeToRead: Math.ceil(getReadingTime(post.body).minutes),
       tags: post.data.tags,
     },
   }));

--- a/src/pages/posts/og-template.ts
+++ b/src/pages/posts/og-template.ts
@@ -26,7 +26,7 @@ export const Template = (props: OGProps, imageBuffer: Buffer) => html`
             month: 'long',
             day: 'numeric',
           })}
-        </time> — <span style="display: flex; margin-left: 8px;">Namchee</span>
+        </time> — <span style="display: flex; margin-left: 8px;">${props.timeToRead} minutes read</span>
       </div>
 
       <div style="display: flex; color: #444CE7;">

--- a/src/pages/posts/og-template.ts
+++ b/src/pages/posts/og-template.ts
@@ -2,17 +2,15 @@
 import { html } from 'satori-html';
 
 interface OGProps {
-  host: string;
-
   title: string;
   publishedAt: Date;
   timeToRead: number;
   tags: string[];
 }
 
-export const Template = (props: OGProps) => html`
+export const Template = (props: OGProps, imageBuffer: Buffer) => html`
   <div style="padding: 48px; margin: 0; display: flex; background-color: #FCFCFD; width: 100%; height: 100%; flex-flow: column; justify-content: space-between">
-    <img width="64" height="64" src='${props.host}/og-logo.png' />
+    <img width="64" height="64" src='data:image/png;base64,${imageBuffer.toString('base64')}' />
 
     <div style="display: flex;">
       <h1 style="font-size: 56px; font-weight: 600; lineHeight: 1; letter-spacing: -2px">


### PR DESCRIPTION
## Overview

This pull request fixes missing logo bug in blog posts open graph images by passing base64 data of the image to the template.

Closes #39