### PR TITLE
feat: restore CF re-deploy

### DIFF
--- a/.github/workflows/webmentions.yml
+++ b/.github/workflows/webmentions.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_TOKEN }}
       - uses: pnpm/action-setup@v2
         with:
           version: 8
@@ -29,3 +31,13 @@ jobs:
           git config user.name "Cristopher Namchee"
           git add .
           git diff --quiet && git diff --staged --quiet || (git commit -m "${COMMIT_MSG}"; git push origin master)
+      - name: Publish to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: 1a99b52ba5412ca55475fdbec4e0ab26
+          projectName: namchee.dev
+          directory: dist
+          # Optional: Switch what branch you are publishing to.
+          # By default this will be the branch which triggered this workflow
+          branch: master

--- a/data/webmentions/hello-world.json
+++ b/data/webmentions/hello-world.json
@@ -1,1 +1,26 @@
-[]
+[
+  {
+    "type": "entry",
+    "author": {
+      "type": "card",
+      "name": "Webmention Rocks!",
+      "photo": "https://webmention.io/avatar/webmention.rocks/e08155b03da96cb1bdfd161ea24efdfad8d85d06afcee540ec246f1f613eb5a9.png",
+      "url": ""
+    },
+    "url": "https://webmention.rocks/receive/1",
+    "published": "2024-06-01T06:32:25-07:00",
+    "wm-received": "2024-06-01T13:35:22Z",
+    "wm-id": 1832512,
+    "wm-source": "https://webmention.rocks/receive/1/9cbcfc14fe75d965644fc7fd7aeee845",
+    "wm-target": "http://www.namchee.dev/posts/hello-world",
+    "wm-protocol": "webmention",
+    "name": "Receiver Test #1",
+    "content": {
+      "html": "<p>This test verifies that you accept a Webmention request that contains a valid source and target URL. To pass this test, your Webmention endpoint must return either HTTP 200, 201 or 202 along with the <a href=\"https://www.w3.org/TR/webmention/#receiving-webmentions\">appropriate headers</a>.</p>\n        <p>If your endpoint returns HTTP 201, then it MUST also return a <code>Location</code> header. If it returns HTTP 200 or 202, then it MUST NOT include a <code>Location</code> header.</p>",
+      "text": "This test verifies that you accept a Webmention request that contains a valid source and target URL. To pass this test, your Webmention endpoint must return either HTTP 200, 201 or 202 along with the appropriate headers.\n        If your endpoint returns HTTP 201, then it MUST also return a Location header. If it returns HTTP 200 or 202, then it MUST NOT include a Location header."
+    },
+    "in-reply-to": "http://www.namchee.dev/posts/hello-world",
+    "wm-property": "in-reply-to",
+    "wm-private": false
+  }
+]

--- a/src/components/astro/modules/posts/SocialLinks.astro
+++ b/src/components/astro/modules/posts/SocialLinks.astro
@@ -42,4 +42,15 @@ const postText = `I just read '${title}' by Namchee
       class=":uno: w-4 md:w-[18px] h-auto transition-color group-hover:text-heading group-focus:text-heading"
     />
   </AppLink>
+
+  <AppLink
+    href={`https://bsky.app/intent/compose?text=${postText}%20${postUrl}`}
+    title="Share Post on Bluesky"
+    class=":uno: group"
+  >
+    <Icon
+      name="simple-icons:bluesky"
+      class=":uno: w-4 md:w-[18px] h-auto transition-color group-hover:text-heading group-focus:text-heading"
+    />
+  </AppLink>
 </div>

--- a/src/scripts/webmentions.ts
+++ b/src/scripts/webmentions.ts
@@ -1,8 +1,5 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
+import { resolve } from 'node:path';
 
 export interface Webmention {
   type: string;
@@ -27,7 +24,7 @@ async function fetchWebmentions() {
   const baseURL = 'https://webmention.io/api/mentions.jf2';
   const params = new URLSearchParams();
 
-  params.append('domain', `www.namchee.dev`);
+  params.append('domain', 'www.namchee.dev');
   params.append('token', process.env.WEBMENTIONS_API_KEY);
   params.append('per-page', '1000');
 

--- a/src/scripts/webmentions.ts
+++ b/src/scripts/webmentions.ts
@@ -27,9 +27,8 @@ async function fetchWebmentions() {
   const baseURL = 'https://webmention.io/api/mentions.jf2';
   const params = new URLSearchParams();
 
-  params.append('domain', `namchee.dev`);
-  // eslint-disable-next-line no-undef
-  params.append('token', process.env.WEBMENTIONS_API_KEY);
+  params.append('domain', `www.namchee.dev`);
+  params.append('token', process.env.WEBMENTION_URL);
   params.append('per-page', '1000');
 
   const response = await fetch(`${baseURL}?${params.toString()}`);

--- a/src/scripts/webmentions.ts
+++ b/src/scripts/webmentions.ts
@@ -28,7 +28,7 @@ async function fetchWebmentions() {
   const params = new URLSearchParams();
 
   params.append('domain', `www.namchee.dev`);
-  params.append('token', process.env.WEBMENTION_URL);
+  params.append('token', process.env.WEBMENTIONS_API_KEY);
   params.append('per-page', '1000');
 
   const response = await fetch(`${baseURL}?${params.toString()}`);
@@ -44,13 +44,12 @@ async function syncWebmentions() {
   const webmentions = await fetchWebmentions();
   for (const mention of webmentions) {
     const slug = new URL(mention['wm-target']).pathname.
-      replace(/\/$/, '').
-      replace(/^\//, '').
-      replaceAll('/', '__');
+      split('/').
+      pop();
 
-    const filename = resolve(__dirname, 'data', 'webmentions', `${slug}.json`);
+    const filename = resolve(process.cwd(), 'data', 'webmentions', `${slug}.json`);
 
-    if (existsSync(filename)) {
+    if (!existsSync(filename)) {
       writeFileSync(filename, JSON.stringify([mention], null, 2));
     } else {
       const entries = JSON.parse(readFileSync(filename, 'utf-8')) as Webmention[];


### PR DESCRIPTION
## Overview

This pull request brings the following changes:

1. **Restore CloudFlare re-deploy on webmentions sync**. Syncing webmentions should require a re-deploy since the webmentions come from a static data.
2. **Add BlueSky share link to posts**