### PR TITLE
chore: bump action version

### DIFF
--- a/.github/workflows/webmentions.yml
+++ b/.github/workflows/webmentions.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_TOKEN }}
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
           version: 8
       - name: Install dependencies
@@ -32,7 +32,7 @@ jobs:
           git add .
           git diff --quiet && git diff --staged --quiet || (git commit -m "${COMMIT_MSG}"; git push origin master)
       - name: Publish to Cloudflare Pages
-        uses: cloudflare/pages-action@v1
+        uses: cloudflare/pages-action@v1.5.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: 1a99b52ba5412ca55475fdbec4e0ab26

--- a/data/webmentions/hello-world.json
+++ b/data/webmentions/hello-world.json
@@ -1,26 +1,3 @@
 [
-  {
-    "type": "entry",
-    "author": {
-      "type": "card",
-      "name": "Webmention Rocks!",
-      "photo": "https://webmention.io/avatar/webmention.rocks/e08155b03da96cb1bdfd161ea24efdfad8d85d06afcee540ec246f1f613eb5a9.png",
-      "url": ""
-    },
-    "url": "https://webmention.rocks/receive/1",
-    "published": "2024-06-01T06:32:25-07:00",
-    "wm-received": "2024-06-01T13:35:22Z",
-    "wm-id": 1832512,
-    "wm-source": "https://webmention.rocks/receive/1/9cbcfc14fe75d965644fc7fd7aeee845",
-    "wm-target": "http://www.namchee.dev/posts/hello-world",
-    "wm-protocol": "webmention",
-    "name": "Receiver Test #1",
-    "content": {
-      "html": "<p>This test verifies that you accept a Webmention request that contains a valid source and target URL. To pass this test, your Webmention endpoint must return either HTTP 200, 201 or 202 along with the <a href=\"https://www.w3.org/TR/webmention/#receiving-webmentions\">appropriate headers</a>.</p>\n        <p>If your endpoint returns HTTP 201, then it MUST also return a <code>Location</code> header. If it returns HTTP 200 or 202, then it MUST NOT include a <code>Location</code> header.</p>",
-      "text": "This test verifies that you accept a Webmention request that contains a valid source and target URL. To pass this test, your Webmention endpoint must return either HTTP 200, 201 or 202 along with the appropriate headers.\n        If your endpoint returns HTTP 201, then it MUST also return a Location header. If it returns HTTP 200 or 202, then it MUST NOT include a Location header."
-    },
-    "in-reply-to": "http://www.namchee.dev/posts/hello-world",
-    "wm-property": "in-reply-to",
-    "wm-private": false
-  }
+
 ]


### PR DESCRIPTION
## Overview

This pull request bumps GitHub Action version that uses Node 16, specifically `checkout`, `pnpm/setup`, and `cloudflare/deploy`.