### PR TITLE
chore(ci): migrate CI to wrangler

### DIFF
--- a/.github/workflows/webmentions.yml
+++ b/.github/workflows/webmentions.yml
@@ -13,7 +13,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_TOKEN }}
-      - uses: pnpm/action-setup@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
         with:
           version: 9.0.2
       - name: Install dependencies
@@ -22,7 +23,7 @@ jobs:
         env:
           WEBMENTIONS_API_KEY: ${{ secrets.WEBMENTIONS_API_KEY }}
         run: pnpm run webmentions:sync
-      - name: Commit to repository
+      - name: Commit webmentions to repository
         env:
           COMMIT_MSG: |
             chore(webmentions): automated sync
@@ -32,12 +33,8 @@ jobs:
           git add .
           git diff --quiet && git diff --staged --quiet || (git commit -m "${COMMIT_MSG}"; git push origin master)
       - name: Publish to Cloudflare Pages
-        uses: cloudflare/pages-action@v1.5.0
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: 1a99b52ba5412ca55475fdbec4e0ab26
-          projectName: namchee.dev
-          directory: dist
-          # Optional: Switch what branch you are publishing to.
-          # By default this will be the branch which triggered this workflow
-          branch: master
+          command: pages deploy dist --project-name=${{ vars.CLOUDFLARE_PROJECT_NAME }} --commit-dirty=true


### PR DESCRIPTION
## Overview

This pull request migrates action for webmentions sync flow from `cloudflare/pages-action` to `cloudflare/wrangler-action` due to deprecation of Node 16. The functionality should be unchanged.