### PR TITLE
fix(ci): add build step before publishing new version to pages

### DIFF
--- a/.github/workflows/webmentions.yml
+++ b/.github/workflows/webmentions.yml
@@ -32,6 +32,8 @@ jobs:
           git config user.name "Cristopher Namchee"
           git add .
           git diff --quiet && git diff --staged --quiet || (git commit -m "${COMMIT_MSG}"; git push origin master)
+      - name: Build the site
+        run: pnpm run build
       - name: Publish to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:


### PR DESCRIPTION
## Overview

This pull request adds build step before publishing to pages on webmentions sync.