### PR TITLE
fix: use correct scaling for post images

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "astro dev",
-    "start": "astro dev",
-    "build": "pnpm run check && astro build",
+    "build": "astro check && astro build",
     "preview": "astro preview",
     "sync": "astro sync",
     "check": "astro check",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@unocss/eslint-config": "^0.59.4",
     "@unocss/reset": "^0.58.9",
     "@unocss/transformer-compile-class": "^0.59.4",
+    "@unpic/pixels": "^1.2.2",
     "astro": "4.10.1",
     "astro-eslint-parser": "^0.16.3",
     "astro-robots-txt": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@unocss/transformer-compile-class':
         specifier: ^0.59.4
         version: 0.59.4
+      '@unpic/pixels':
+        specifier: ^1.2.2
+        version: 1.2.2
       astro:
         specifier: 4.10.1
         version: 4.10.1(@types/node@20.14.2)(typescript@5.4.5)

--- a/src/assets/styles/tweet.css
+++ b/src/assets/styles/tweet.css
@@ -1,4 +1,6 @@
 .astro-tweet-theme {
+  background: oklch(var(--background)) !important;
+  color: oklch(var(--content)) !important;
   border: 1px solid oklch(var(--content) / 0.25) !important;
   margin-top: 2rem !important;
   margin-bottom: 2rem !important;
@@ -10,4 +12,5 @@
 
 html.dark .astro-tweet-theme {
   background: oklch(var(--surface)) !important;
+  color: oklch(var(--heading)) !important;
 }

--- a/src/components/astro/modules/posts/PostLayout.astro
+++ b/src/components/astro/modules/posts/PostLayout.astro
@@ -4,8 +4,6 @@ import { Icon } from "astro-icon/components";
 import type { CollectionEntry } from "astro:content";
 import type { MarkdownFile } from "@/plugins/remark/types";
 
-import Tweet from 'astro-tweet';
-
 import Layout from "@/components/astro/layout/Layout.astro";
 import Badge from "@/components/astro/ui/Badge.astro";
 

--- a/src/components/astro/modules/posts/TableOfContents.astro
+++ b/src/components/astro/modules/posts/TableOfContents.astro
@@ -16,7 +16,7 @@ const tocList = generateToC(headings);
 ---
 
 <nav
-  class=":uno: text-sm flex-col hidden md:flex md:sticky bottom-0 p-4 rounded-md md:mb-0 top-24 md:p-0 mb-8"
+  class=":uno: text-sm hidden top-24 sticky md:block xl:mr-4"
 >
   <p class=":uno: mb-4 font-semibold text-heading transition-colors">
     In this post

--- a/src/components/astro/modules/posts/html/Image.astro
+++ b/src/components/astro/modules/posts/html/Image.astro
@@ -24,6 +24,7 @@ const scaledHeight = Math.ceil(MAX_WIDTH / width * height);
     height={scaledHeight}
     class=":uno: rounded-md"
     placeholder="blurhash"
+    loading="lazy"
   />
 
   <figcaption class=":uno: text-xs text-center mt-2 italic">

--- a/src/components/astro/modules/posts/html/Image.astro
+++ b/src/components/astro/modules/posts/html/Image.astro
@@ -1,11 +1,18 @@
 ---
 import { Image as Img } from "@unpic/astro";
+import { getPixels } from '@unpic/pixels';
 
 import type { HTMLAttributes } from "astro/types";
 
 type Props = HTMLAttributes<"img">;
 
+// the maximum image width on 1023px
+const MAX_WIDTH = 703;
+
 const { alt, src } = Astro.props;
+
+const { width, height } = await getPixels(src);
+const scaledHeight = Math.ceil(MAX_WIDTH / width * height);
 ---
 
 <figure class="mt-8! mb-8!">
@@ -13,8 +20,8 @@ const { alt, src } = Astro.props;
     src={src}
     alt={alt}
     title={alt}
-    width={703}
-    height={420}
+    width={MAX_WIDTH}
+    height={scaledHeight}
     class=":uno: rounded-md"
     placeholder="blurhash"
   />

--- a/src/components/vue/CopyCode.vue
+++ b/src/components/vue/CopyCode.vue
@@ -32,7 +32,7 @@ function copyCode() {
 
       <TooltipPortal>
         <TooltipContent
-          class="text-xs shadow shadow tooltip__content text-background select-none rounded-md bg-primary py-2 px-3 will-change-[transform,opacity]"
+          class="text-xs rounded-md shadow shadow tooltip__content text-background select-none bg-primary py-2 px-3 will-change-[transform,opacity]"
           :side-offset="5"
         >
           Copied!

--- a/src/content/posts/test-page.mdx
+++ b/src/content/posts/test-page.mdx
@@ -78,7 +78,7 @@ function testAdd() {
 }
 ```
 
-## Surely It Works 🙃
+## Plant bullets in their lines
 
 Diam nisl sit volutpat est pellentesque aliquet porttitor egestas commodo. Purus vitae egestas nunc turpis urna placerat proin dui mi. Iaculis sed in dui nisl. Hendrerit odio lectus enim vitae euismod enim. Urna lorem scelerisque nunc leo nunc odio mauris sed sed. Pharetra cras aenean tincidunt morbi purus molestie.
 

--- a/src/content/posts/test-page.mdx
+++ b/src/content/posts/test-page.mdx
@@ -78,7 +78,7 @@ function testAdd() {
 }
 ```
 
-## If my Girl 👸🥰 & Mo Ye 🤑🤩
+## Surely It Works 🙃
 
 Diam nisl sit volutpat est pellentesque aliquet porttitor egestas commodo. Purus vitae egestas nunc turpis urna placerat proin dui mi. Iaculis sed in dui nisl. Hendrerit odio lectus enim vitae euismod enim. Urna lorem scelerisque nunc leo nunc odio mauris sed sed. Pharetra cras aenean tincidunt morbi purus molestie.
 

--- a/src/pages/posts/_og-template.ts
+++ b/src/pages/posts/_og-template.ts
@@ -13,7 +13,7 @@ export const Template = (props: OGProps, imageBuffer: Buffer) => html`
     <img width="64" height="64" src='data:image/png;base64,${imageBuffer.toString('base64')}' />
 
     <div style="display: flex;">
-      <h1 style="font-size: 56px; font-weight: 600; lineHeight: 1; letter-spacing: -2px">
+      <h1 style="font-size: 64px; font-weight: 600; lineHeight: 1; letter-spacing: -2px">
         ${props.title}
       </h1>
     </div>

--- a/src/pages/posts/og-[...slug].png.ts
+++ b/src/pages/posts/og-[...slug].png.ts
@@ -7,7 +7,7 @@ import satori, { type SatoriOptions } from 'satori';
 import sharp from 'sharp';
 import getReadingTime from 'reading-time';
 
-import { Template } from './og-template';
+import { Template } from './_og-template';
 
 interface Params {
   title: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     }
   },
   "extends": "astro/tsconfigs/base",
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "dist", "public", "eslint.config.js"]
 }


### PR DESCRIPTION
## Overview

This pull request introduces the following changes:

1. **Set image size correctly by calculating dimensions**. Before #50, all images uses `fullWidth` layout that may lead to unoptimized image size. PR #50 introduces static `width` and `height` to resolve the issue. However, it doesn't take account for non-landscape images and it enforces those images to be landscape. This PR solves the issue by calculating the original image dimensions using `@unpic/pixels` and scale them down.
2. **Add extra padding to table of contents on `xl` breakpoint**. Previously, the table of contents has 16px spacing to the post body. This is too tight and may cause UX issues. The spacing has been extended to 32px.
3. **Register public, build, and ESLint config to ts-check**. Build outputs and unrelated files shouldn't be checked by `astro check`.