### PR TITLE
refactor: remove useThrottleFn as it is unused

### DIFF
--- a/src/components/astro/layout/Layout.astro
+++ b/src/components/astro/layout/Layout.astro
@@ -61,7 +61,7 @@ const ogFile = og ? `${og}.png` : 'og.png';
       href="https://webmention.io/www.namchee.dev/webmention"
     />
     <link rel="preload" href="/fonts/pretendard.woff2" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="/fonts/pretendard.woff2" as="font" type="font/woff2" crossorigin>
+
     <title>{title}</title>
     <script is:inline>
       // do not try to optimize this. is:inline is there to avoid pre-opt that causes theme flicker

--- a/src/components/astro/layout/Layout.astro
+++ b/src/components/astro/layout/Layout.astro
@@ -61,6 +61,7 @@ const ogFile = og ? `${og}.png` : 'og.png';
       href="https://webmention.io/www.namchee.dev/webmention"
     />
     <link rel="preload" href="/fonts/pretendard.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="/fonts/pretendard.woff2" as="font" type="font/woff2" crossorigin>
     <title>{title}</title>
     <script is:inline>
       // do not try to optimize this. is:inline is there to avoid pre-opt that causes theme flicker

--- a/src/components/vue/CommandMenu.vue
+++ b/src/components/vue/CommandMenu.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, watch, computed, nextTick } from 'vue';
-import { useMagicKeys, useThrottleFn, whenever } from '@vueuse/core';
+import { useMagicKeys, whenever } from '@vueuse/core';
 
 import {
   DialogRoot,


### PR DESCRIPTION
## Overview

This pull request removes `useThrottleFn` import in `CommandMenu` as it's unused.