### PR TITLE
feat: restore reading indicators

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,6 +1,6 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1731852794262
+		"lastUpdateCheck": 1732978696644
 	},
 	"devToolbar": {
 		"enabled": false

--- a/src/components/astro/layout/Footer.astro
+++ b/src/components/astro/layout/Footer.astro
@@ -22,9 +22,9 @@ const contacts = [
 ];
 ---
 
-<footer class=":uno: w-full mx-auto text-sm py-8 lg:pb-[43px] pb-24 px-8">
+<footer class=":uno: w-full mx-auto text-sm py-8 md:pb-[43px] pb-24 px-8">
   <div
-    class="flex lg:flex-col items-center space-x-4 lg:space-x-0 lg:space-y-4"
+    class="flex md:flex-col items-center space-x-4 lg:space-x-0 md:space-y-4"
   >
     <Logo class="w-8 h-[36px]" />
 
@@ -46,7 +46,7 @@ const contacts = [
     </div>
   </div>
 
-  <div class="flex items-center justify-between mt-4 lg:mt-[43px]">
+  <div class="flex items-center justify-between mt-4 md:mt-[43px]">
     <p>
       &copy; Namchee. <AppLink
         class="hover:text-heading focus:text-heading transition-colors font-medium text-heading/85"

--- a/src/components/astro/layout/Footer.astro
+++ b/src/components/astro/layout/Footer.astro
@@ -22,9 +22,9 @@ const contacts = [
 ];
 ---
 
-<footer class=":uno: w-full mx-auto text-sm py-8 md:pb-[43px] pb-24 px-8">
+<footer class=":uno: w-full mx-auto text-sm py-8 lg:pb-[43px] pb-24 px-8">
   <div
-    class="flex md:flex-col items-center space-x-4 md:space-x-0 md:space-y-4"
+    class="flex lg:flex-col items-center space-x-4 lg:space-x-0 lg:space-y-4"
   >
     <Logo class="w-8 h-[36px]" />
 
@@ -46,7 +46,7 @@ const contacts = [
     </div>
   </div>
 
-  <div class="flex items-center justify-between mt-4 md:mt-[43px]">
+  <div class="flex items-center justify-between mt-4 lg:mt-[43px]">
     <p>
       &copy; Namchee. <AppLink
         class="hover:text-heading focus:text-heading transition-colors font-medium text-heading/85"

--- a/src/components/astro/layout/Layout.astro
+++ b/src/components/astro/layout/Layout.astro
@@ -115,7 +115,7 @@ const ogFile = og ? `${og}.png` : "og.png";
   >
     <Navigation posts={posts} />
 
-    <main class=":uno: w-full mx-auto flex-1 max-w-[832px] px-8 leading-[1.75] my-32 space-y-16">
+    <main class=":uno: w-full mx-auto flex-1 max-w-[832px] px-8 leading-[1.75] mt-24 mb-32 md:mt-32 space-y-16">
       <slot />
     </main>
 

--- a/src/components/astro/modules/posts/PostLayout.astro
+++ b/src/components/astro/modules/posts/PostLayout.astro
@@ -33,8 +33,8 @@ const lastModified = !!frontmatter.lastModified
 
 
 <progress
-    class=":uno: fixed w-screen z-10 reading__progress h-[2px] left-0 top-0"
-  ></progress>
+  class=":uno: fixed w-screen z-10 reading__progress h-[2px] left-0 top-0"
+/>
 
 <Layout
   title={`${frontmatter.title} — Namchee`}
@@ -48,7 +48,7 @@ const lastModified = !!frontmatter.lastModified
       <Icon slot="btt" name="lucide:corner-left-up" class=":uno: w-4 h-auto" />
     </TableOfContentsWrapper>
 
-    <BackToTop client:load>
+    <BackToTop client:visible>
       <Icon name="lucide:arrow-up" class=":uno: w-5 h-auto" />
     </BackToTop>
 

--- a/src/components/astro/modules/posts/PostLayout.astro
+++ b/src/components/astro/modules/posts/PostLayout.astro
@@ -36,15 +36,15 @@ const lastModified = !!frontmatter.lastModified
   description={frontmatter.subtitle}
   og={`posts/og-${frontmatter.slug}`}
 >
+  <progress
+    class=":uno: fixed w-screen z-10 reading__progress h-[2px] left-0 top-0"
+  ></progress>
+
   <article class=":uno: grid grid-cols-12 gap-4">
     <TableOfContentsWrapper client:visible>
       <Icon slot="button" name="lucide:table-of-contents" class="w-5 h-auto" />
       <TableOfContents slot="toc" headings={frontmatter.headings} />
-      <Icon
-        slot="btt"
-        name="lucide:corner-left-up"
-        class=":uno: w-4 h-auto"
-      />
+      <Icon slot="btt" name="lucide:corner-left-up" class=":uno: w-4 h-auto" />
     </TableOfContentsWrapper>
 
     <BackToTop client:load>
@@ -54,7 +54,9 @@ const lastModified = !!frontmatter.lastModified
     <header class=":uno: col-start-1 col-end-13 md:col-start-2 md:col-end-12">
       <BackButton />
 
-      <h1 class=":uno: text-heading tracking-tight text-2xl md:text-4xl leading-normal font-semibold mt-4 transition-colors">
+      <h1
+        class=":uno: text-heading tracking-tight text-2xl md:text-4xl leading-normal font-semibold mt-4 transition-colors"
+      >
         {frontmatter.title}
       </h1>
 
@@ -118,9 +120,7 @@ const lastModified = !!frontmatter.lastModified
       <slot />
     </section>
 
-    <section
-      class=":uno: flex col-start-1 col-end-13 justify-between mt-16"
-    >
+    <section class=":uno: flex col-start-1 col-end-13 justify-between mt-16">
       <div>
         <p class=":uno: font-semibold text-sm leading-normal md:text-base mb-5">
           Share this Post
@@ -153,15 +153,16 @@ const lastModified = !!frontmatter.lastModified
     background-color: oklch(var(--background));
   }
   .reading__progress::-webkit-progress-value {
-    background-color: oklch(var(--primary));
+    background-color: oklch(var(--heading));
   }
 
   .reading__progress::-moz-progress-bar {
-    background-color: oklch(var(--primary));
+    background-color: oklch(var(--heading));
   }
 </style>
 
 <script>
+  // table of contents
   let currentActiveLink = null;
 
   const observer = new IntersectionObserver((entries) => {
@@ -169,7 +170,10 @@ const lastModified = !!frontmatter.lastModified
 
     entries.forEach((entry) => {
       if (entry.intersectionRatio > 0) {
-        if (!mostVisibleEntry || entry.intersectionRatio > mostVisibleEntry.intersectionRatio) {
+        if (
+          !mostVisibleEntry ||
+          entry.intersectionRatio > mostVisibleEntry.intersectionRatio
+        ) {
           mostVisibleEntry = entry;
         }
       }
@@ -177,7 +181,9 @@ const lastModified = !!frontmatter.lastModified
 
     if (mostVisibleEntry) {
       const id = mostVisibleEntry.target.id;
-      const newActiveLink = document.querySelector(`nav ul li a[href="#${id}"]`);
+      const newActiveLink = document.querySelector(
+        `nav ul li a[href="#${id}"]`
+      );
 
       if (newActiveLink && currentActiveLink !== newActiveLink) {
         if (currentActiveLink) {
@@ -191,10 +197,8 @@ const lastModified = !!frontmatter.lastModified
 
   const tocLinks = document.querySelectorAll("h2[id], h3[id]");
   tocLinks.forEach((link) => observer.observe(link));
-</script>
 
-
-<!-- <script>
+  // reading progress indicator
   const progressBar = document.querySelector(".reading__progress");
 
   const windowHeight = window.innerHeight;
@@ -205,9 +209,4 @@ const lastModified = !!frontmatter.lastModified
   window.addEventListener("scroll", () => {
     progressBar.setAttribute("value", window.scrollY.toString());
   });
-
-  const backToTop = document.querySelector(".backToTop__button");
-  backToTop.addEventListener("click", () => {
-    window.scrollTo(0, 0);
-  });
-</script> -->
+</script>

--- a/src/components/astro/modules/posts/PostLayout.astro
+++ b/src/components/astro/modules/posts/PostLayout.astro
@@ -31,15 +31,16 @@ const lastModified = !!frontmatter.lastModified
   : publishedAt;
 ---
 
+
+<progress
+    class=":uno: fixed w-screen z-10 reading__progress h-[2px] left-0 top-0"
+  ></progress>
+
 <Layout
   title={`${frontmatter.title} — Namchee`}
   description={frontmatter.subtitle}
   og={`posts/og-${frontmatter.slug}`}
 >
-  <progress
-    class=":uno: fixed w-screen z-10 reading__progress h-[2px] left-0 top-0"
-  ></progress>
-
   <article class=":uno: grid grid-cols-12 gap-4">
     <TableOfContentsWrapper client:visible>
       <Icon slot="button" name="lucide:table-of-contents" class="w-5 h-auto" />

--- a/src/components/astro/modules/posts/TocList.astro
+++ b/src/components/astro/modules/posts/TocList.astro
@@ -21,8 +21,7 @@ const marginMap = {
   {headings.map(
     head => (
       <li class={marginMap[head.depth]}>
-        <!-- temporarily disabled -->
-        <AppLink href={`#${head.slug}`} class=":uno: text-content transition-all text-sm block" tabindex={-1}>
+        <AppLink href={`#${head.slug}`} class=":uno: text-content transition-all text-sm block">
           {head.text}
         </AppLink>
 

--- a/src/components/astro/modules/posts/TocList.astro
+++ b/src/components/astro/modules/posts/TocList.astro
@@ -21,7 +21,7 @@ const marginMap = {
   {headings.map(
     head => (
       <li class={marginMap[head.depth]}>
-        <AppLink href={`#${head.slug}`} class=":uno: text-content transition-all text-sm block">
+        <AppLink href={`#${head.slug}`} class=":uno: text-content transition-all text-sm block" tabindex={-1}>
           {head.text}
         </AppLink>
 

--- a/src/components/vue/BackToTop.vue
+++ b/src/components/vue/BackToTop.vue
@@ -10,7 +10,7 @@ function backToTop() {
 
 <template>
   <div
-    class=":uno: fixed border border-navigation-border bottom-8 right-8 z-40 grid place-items-center p-1 shadow bg-navigation-background transition-colors text-content rounded-md shadow-md lg:hidden"
+    class=":uno: fixed border border-navigation-border bottom-8 right-8 z-40 grid place-items-center p-1 shadow bg-navigation-background transition-colors text-content rounded-md shadow-md md:hidden"
   >
     <TooltipProvider :delay-duration="100">
       <TooltipRoot>

--- a/src/components/vue/TableOfContents.vue
+++ b/src/components/vue/TableOfContents.vue
@@ -22,7 +22,7 @@ onMounted(() => {
 
 <template>
   <div
-    class=":uno: border border-navigation-border bottom-8 left-8 z-40 grid place-items-center p-1 lg:p-0 lg:border-none shadow lg:shadow-none lg:bg-transparent bg-navigation-background lg:top-32 lg:bottom-unset transition-colors text-content rounded-md shadow-md lg:shadow-none fixed"
+    class=":uno: border border-navigation-border bottom-8 left-8 z-40 grid place-items-center p-1 md:p-0 md:border-none shadow md:shadow-none md:bg-transparent bg-navigation-background md:top-32 md:bottom-unset transition-colors text-content rounded-md shadow-md fixed"
   >
     <TooltipProvider :delay-duration="100">
       <TooltipRoot>
@@ -42,7 +42,7 @@ onMounted(() => {
               :side-offset="isDesktop ? 0 : 5"
               :align="isDesktop ? 'center' : 'start'"
               :align-offset="isDesktop ? 0 : -4"
-              class="rounded-md text-sm py-2 tooltip__content bg-content text-background lg:bg-transparent lg:text-unset lg:border-none select-none px-3 will-change-[transform,opacity]"
+              class="rounded-md text-sm py-2 tooltip__content bg-content text-background xl:bg-transparent xl:text-unset xl:border-none select-none px-3 will-change-[transform,opacity]"
             >
               <p>Table of Contents</p>
 
@@ -65,12 +65,12 @@ onMounted(() => {
                 }
               }"
               :force-mount="true"
-              class=":uno: lg:mt-4 lg:mb-0 mb-4 border border-navigation-border rounded-md xl:rounded-none xl:shadow-none shadow-md bg-navigation-background p-4 xl:p-0 xl:bg-transparent xl:translate-x-0 -translate-x-1 xl:border-none transition-all origin-bottom-left lg:origin-top-left data-[state=closed]:opacity-0 data-[state=opened]:opacity-100 data-[state=closed]:scale-95 data-[state=opened]:scale-100"
+              class=":uno: md:mt-4 md:mb-0 mb-4 border border-navigation-border rounded-md xl:rounded-none xl:shadow-none shadow-md bg-navigation-background p-4 xl:p-0 xl:bg-transparent xl:translate-x-0 -translate-x-1 xl:border-none transition-all origin-bottom-left lg:origin-top-left data-[state=closed]:opacity-0 data-[state=opened]:opacity-100 data-[state=closed]:scale-95 data-[state=opened]:scale-100"
             >
               <slot name="toc" />
 
               <button
-                class=":uno: lg:items-center space-x-2 mt-8 text-heading hidden transition-colors lg:flex text-sm"
+                class=":uno: lg:items-center space-x-2 mt-8 text-heading hidden transition-colors md:flex text-sm"
                 @click="backToTop"
                 :tabindex="-1"
               >

--- a/src/pages/library.astro
+++ b/src/pages/library.astro
@@ -58,6 +58,11 @@ const books = {
       author: "Alex Xu",
       link: "https://literal.club/book/alex-xu-system-design-interview-an-insiders-guide-i97ig",
     },
+    {
+      title: '100 Go Mistakes',
+      author: 'Teiva Harsanyi',
+      link: 'https://literal.club/namchee/book/teiva-harsanyi-100-go-mistakes-how-to-avoid-them-ix8kd'
+    }
   ],
 };
 


### PR DESCRIPTION
## Overview

This pull request introduces the following changes:

1. Restores reading indicator on the top of blog posts
2. Fixes blog posts navigation for tablet devices by moving the ToC trigger to the top-left of the posts
3. Reduce top margin of layouts for mobile devices to 24