### PR TITLE
fix: add fonttools postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "webmentions:sync": "tsx ./src/scripts/webmentions.ts",
-    "postinstall": "pnpm exec playwright install"
+    "postinstall": "pnpm exec playwright install && pip install fonttools brotli zopfli"
   },
   "devDependencies": {
     "@astrojs/mdx": "^4.0.3",


### PR DESCRIPTION
## Overview

Fixes #87 

This pull request adds `fonttools` stack explicitly.