### PR TITLE
chore: add .zed config

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,69 @@
+// Folder-specific settings
+//
+// For a full list of overridable settings, and general information on folder-specific settings,
+// see the documentation: https://zed.dev/docs/configuring-zed#settings-files
+{
+  // =====================
+  // Formatting
+  // =====================
+  "format_on_save": "on",
+  // Zed does not use Prettier directly like VS Code
+  // Formatting is handled by language servers / external formatters
+  "formatter": "language_server",
+  // =====================
+  // Code Actions on Save
+  // =====================
+  "code_actions_on_format": {
+    "source.fixAll.eslint": true,
+    "source.organizeImports": true
+  },
+  // =====================
+  // Language Validation
+  // =====================
+  "languages": {
+    "JavaScript": {
+      "language_servers": [
+        "eslint",
+        "typescript-language-server"
+      ]
+    },
+    "TypeScript": {
+      "language_servers": [
+        "eslint",
+        "typescript-language-server"
+      ]
+    },
+    "Vue.js": {
+      "language_servers": [
+        "eslint",
+        "vue-language-server"
+      ]
+    },
+    "HTML": {
+      "language_servers": [
+        "eslint"
+      ]
+    },
+    "Markdown": {
+      "language_servers": [
+        "eslint"
+      ]
+    },
+    "JSON": {
+      "language_servers": [
+        "eslint"
+      ]
+    },
+    "YAML": {
+      "language_servers": [
+        "eslint"
+      ]
+    },
+    "Astro": {
+      "language_servers": [
+        "eslint",
+        "astro-language-server"
+      ]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "astro-robots-txt": "^1.0.0",
     "astro-tweet": "^0.0.4",
     "eslint": "^9.34.0",
+    "eslint-import-resolver-node": "^0.3.9",
     "github-slugger": "^2.0.0",
     "glyphhanger": "^5.0.0",
     "jiti": "^2.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,7 @@ importers:
         version: 0.1.0(astro@5.12.8(@types/node@20.19.0)(jiti@2.5.1)(rollup@4.42.0)(terser@5.43.1)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.1))
       '@namchee/eslint-config':
         specifier: ^3.1.2
-        version: 3.1.2(@types/estree@1.0.8)(@unocss/eslint-plugin@66.5.1(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3))(@vue/compiler-sfc@3.5.16)(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.2(@types/debug@4.1.12)(@types/node@20.19.0)(jiti@2.5.1)(jsdom@23.2.0)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.1))
+        version: 3.1.2(@types/estree@1.0.8)(@unocss/eslint-plugin@66.5.1(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3))(@vue/compiler-sfc@3.5.16)(eslint-import-resolver-node@0.3.9)(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.2(@types/debug@4.1.12)(@types/node@20.19.0)(jiti@2.5.1)(jsdom@23.2.0)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.1))
       '@shikijs/transformers':
         specifier: ^3.6.0
         version: 3.6.0
@@ -90,6 +90,9 @@ importers:
       eslint:
         specifier: ^9.34.0
         version: 9.34.0(jiti@2.5.1)
+      eslint-import-resolver-node:
+        specifier: ^0.3.9
+        version: 0.3.9
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
@@ -3084,6 +3087,9 @@ packages:
 
   eslint-flat-config-utils@2.1.1:
     resolution: {integrity: sha512-K8eaPkBemHkfbYsZH7z4lZ/tt6gNSsVh535Wh9W9gQBS2WjvfUbbVr2NZR3L1yiRCLuOEimYfPxCxODczD4Opg==}
+
+  eslint-import-resolver-node@0.3.9:
+    resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
 
   eslint-import-resolver-typescript@3.10.1:
     resolution: {integrity: sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==}
@@ -7534,7 +7540,7 @@ snapshots:
     transitivePeerDependencies:
       - '@astrojs/db'
 
-  '@namchee/eslint-config@3.1.2(@types/estree@1.0.8)(@unocss/eslint-plugin@66.5.1(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3))(@vue/compiler-sfc@3.5.16)(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.2(@types/debug@4.1.12)(@types/node@20.19.0)(jiti@2.5.1)(jsdom@23.2.0)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.1))':
+  '@namchee/eslint-config@3.1.2(@types/estree@1.0.8)(@unocss/eslint-plugin@66.5.1(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3))(@vue/compiler-sfc@3.5.16)(eslint-import-resolver-node@0.3.9)(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.2(@types/debug@4.1.12)(@types/node@20.19.0)(jiti@2.5.1)(jsdom@23.2.0)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.1))':
     dependencies:
       '@antfu/eslint-config': 5.3.0(@unocss/eslint-plugin@66.5.1(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3))(@vue/compiler-sfc@3.5.16)(astro-eslint-parser@1.2.2)(eslint-plugin-astro@1.3.1(eslint@9.34.0(jiti@2.5.1)))(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)(vitest@3.2.2(@types/debug@4.1.12)(@types/node@20.19.0)(jiti@2.5.1)(jsdom@23.2.0)(terser@5.43.1)(tsx@4.19.4)(yaml@2.8.1))
       '@eslint/js': 9.34.0
@@ -7546,7 +7552,7 @@ snapshots:
       astro-eslint-parser: 1.2.2
       eslint: 9.34.0(jiti@2.5.1)
       eslint-plugin-astro: 1.3.1(eslint@9.34.0(jiti@2.5.1))
-      eslint-plugin-canonical: 5.1.3(@typescript-eslint/parser@8.43.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)
+      eslint-plugin-canonical: 5.1.3(@typescript-eslint/parser@8.43.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)
       eslint-plugin-import-lite: 0.3.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)
       eslint-plugin-jsonc: 2.20.1(eslint@9.34.0(jiti@2.5.1))
       eslint-plugin-n: 17.21.3(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)
@@ -10038,6 +10044,14 @@ snapshots:
     dependencies:
       pathe: 2.0.3
 
+  eslint-import-resolver-node@0.3.9:
+    dependencies:
+      debug: 3.2.7
+      is-core-module: 2.16.1
+      resolve: 1.22.10
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.10.1(eslint@9.34.0(jiti@2.5.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -10061,12 +10075,13 @@ snapshots:
     dependencies:
       eslint: 9.34.0(jiti@2.5.1)
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.43.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint@9.34.0(jiti@2.5.1)))(eslint@9.34.0(jiti@2.5.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.43.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint@9.34.0(jiti@2.5.1)))(eslint@9.34.0(jiti@2.5.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.43.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)
       eslint: 9.34.0(jiti@2.5.1)
+      eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint@9.34.0(jiti@2.5.1))
     transitivePeerDependencies:
       - supports-color
@@ -10089,14 +10104,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-canonical@5.1.3(@typescript-eslint/parser@8.43.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3):
+  eslint-plugin-canonical@5.1.3(@typescript-eslint/parser@8.43.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3):
     dependencies:
       '@typescript-eslint/utils': 8.43.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3)
       array-includes: 3.1.9
       debug: 4.4.1
       doctrine: 3.0.0
       eslint-import-resolver-typescript: 3.10.1(eslint@9.34.0(jiti@2.5.1))
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.43.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint@9.34.0(jiti@2.5.1)))(eslint@9.34.0(jiti@2.5.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.43.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint@9.34.0(jiti@2.5.1)))(eslint@9.34.0(jiti@2.5.1))
       is-get-set-prop: 1.0.0
       is-js-type: 2.0.0
       is-obj-prop: 1.0.0

--- a/src/components/astro/layout/Layout.astro
+++ b/src/components/astro/layout/Layout.astro
@@ -111,8 +111,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
       is:inline
       defer
       src="https://cloud.umami.is/script.js"
-      data-website-id="16f41ca8-561c-4f45-8943-0c80934f59ff">
-    </script>
+      data-website-id="16f41ca8-561c-4f45-8943-0c80934f59ff"></script>
   </head>
   <body
     vaul-drawer-wrapper

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,15 +1,15 @@
-import { defineCollection, z } from "astro:content";
-import { glob } from "astro/loaders";
+import { glob } from 'astro/loaders';
+import { defineCollection, z } from 'astro:content';
 
 const posts = defineCollection({
-	loader: glob({ pattern: "**/*.{md,mdx}", base: "posts" }),
-	schema: z.object({
-		title: z.string(),
-		subtitle: z.string(),
-		tags: z.array(z.string()),
-		publishedAt: z.date(),
-		isDraft: z.boolean().optional().default(false),
-	}),
+  loader: glob({ pattern: '**/*.{md,mdx}', base: 'posts' }),
+  schema: z.object({
+    title: z.string(),
+    subtitle: z.string(),
+    tags: z.array(z.string()),
+    publishedAt: z.date(),
+    isDraft: z.boolean().optional().default(false),
+  }),
 });
 
 export const collections = { posts };

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -94,4 +94,3 @@ import '@/assets/styles/fonts.css';
     </script>
   </body>
 </html>
-

--- a/src/pages/posts/og-[...slug].png.ts
+++ b/src/pages/posts/og-[...slug].png.ts
@@ -1,3 +1,4 @@
+
 import { readFileSync } from 'node:fs';
 
 import { getCollection } from 'astro:content';

--- a/src/plugins/remark/sectionize.ts
+++ b/src/plugins/remark/sectionize.ts
@@ -1,7 +1,7 @@
-import type { Heading, Node, Parent, Root, RootContent } from 'mdast';
 /**
  * Code is taken from 'remark-sectionize' by Jake Low with few modifications.
  */
+import type { Heading, Node, Parent, Root, RootContent } from 'mdast';
 import type { Transformer } from 'unified';
 
 import { slug } from 'github-slugger';
@@ -28,7 +28,7 @@ function sectionize(node: Heading, index: number, parent: Parent) {
   const startIndex = index;
   const depth = start.depth;
 
-  const isEnd = (node: Node) => node.type === 'heading' && (node as Heading).depth <= depth || node.type === 'export';
+  const isEnd = (node: Node) => (node.type === 'heading' && (node as Heading).depth <= depth) || node.type === 'export';
   const end = findAfter(parent, start, isEnd);
   const endIndex = parent.children.indexOf(end!);
 

--- a/src/scripts/toc.test.ts
+++ b/src/scripts/toc.test.ts
@@ -39,9 +39,9 @@ describe('generateToC', () => {
             text: 'b',
             subheadings: [],
           },
-        ]
-      }
-    ])
+        ],
+      },
+    ]);
   });
 
   it('should return nested ToC with returns', () => {
@@ -122,9 +122,9 @@ describe('generateToC', () => {
                 text: 'd',
                 subheadings: [],
               },
-            ]
-          }
-        ]
+            ],
+          },
+        ],
       },
       {
         depth: 2,
@@ -149,8 +149,8 @@ describe('generateToC', () => {
             slug: 'h',
             text: 'h',
             subheadings: [],
-          }
-        ]
+          },
+        ],
       },
       {
         depth: 2,
@@ -162,9 +162,9 @@ describe('generateToC', () => {
             slug: 'j',
             text: 'j',
             subheadings: [],
-          }
-        ]
-      }
-    ])
+          },
+        ],
+      },
+    ]);
   });
-})
+});


### PR DESCRIPTION
## Overview

This pull request adds `.zed` folder since I use [Zed](https://zed.dev/) now. However, this doesn't remove `.vscode` completely since there are chances of me migrating back.